### PR TITLE
#19, 해결대기와 해결완료 데이터 전송시 배열이 아닌 협의된 문자로 송신

### DIFF
--- a/src/components/board/BoardController/index.tsx
+++ b/src/components/board/BoardController/index.tsx
@@ -4,7 +4,7 @@ import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useQueryClient } from '@tanstack/react-query';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Filters } from '../../../requestType/postType.ts';
 
@@ -46,13 +46,7 @@ function BoardController({ filters, setFilters }: Props) {
 
   // 필터 (해결대기, 해결완료)
   const handleStatusChange = (status: string) => {
-    // console.log('handleStatusChange');
-    setFilters(prevFilters => {
-      const newStatus = prevFilters.status.includes(status)
-        ? prevFilters.status.filter(s => s !== status)
-        : [...prevFilters.status, status];
-      return { ...prevFilters, status: newStatus };
-    });
+    // console.log(`isPendingBefore : ${isPending}`)
     if (status === 'wait') {
       setIsPending(!isPending);
     } else if (status === 'finish') {
@@ -60,6 +54,24 @@ function BoardController({ filters, setFilters }: Props) {
     }
     setActiveButton(status);
   };
+
+  // 해결대기와 해결완료 데이터 변경시 setFilters 에 데이터 반영
+  useEffect(() => {
+    let newStaus;
+    if (isPending && isCompleted) {
+      newStaus = ['wait', 'finish']
+    } else if (!isPending && isCompleted) {
+      newStaus = ['finish']
+    } else if (isPending && !isCompleted) {
+      newStaus = ['wait']
+    } else {
+      newStaus = ['wait', 'finish']
+    }
+    // console.log(`newStaus : ${newStaus}`)
+    setFilters(prevFilters => {
+      return { ...prevFilters, status: newStaus };
+    });
+  }, [isPending, isCompleted]);
 
   // 전체(검색 조건 리셋)
   const handleResetFilters = () => {

--- a/src/requestType/postType.ts
+++ b/src/requestType/postType.ts
@@ -8,3 +8,14 @@ export type Filters = {
     size: number;
   };
 };
+
+export type RequestFilters = {
+  search: string;
+  categories: string;
+  sortBy: string;
+  status: string;
+  pageInfo: {
+    page: number;
+    size: number;
+  };
+};


### PR DESCRIPTION
## 🚀 Related Issues
> https://github.com/ChatCode9/ChatCode-frontend/issues/19
## 🛠️ Summary
> 전송시 해결대기, 해결완료 데이터 타입 String[] -> String 변경

```diff
- status : ['wait','finish']
+ status : 'wait' or 'finish' or 'emptyString'
```
원래라면 status 타입을 String[]을 String 으로 변경처리 할려고 했으나

String 타입 변경시 Service > Post.tsx 단계에서 status 데이터가 'wait' 과 'finish' 2개의 상태 데이터를 가지고 있지않아

프론트측에서만 String[] 상태로 관리하고 최종적으로 서버단에 보내기전
transformFilters 함수를 통해 String 데이터로 정제한 후 송신

```javascript
const fetchPosts = async (filters: RequestFilters): Promise<Question> => {
  const { search, categories, sortBy, pageInfo } = filters;
  let { status } = filters;
  if(status === '' || status === 'wait,finish' || status === 'finish,wait'){
    // 해결대기, 해결완료 모두 선택 했거나 또는 모두 선택하지 않는다면 API 전송시 데이터를 채워준다
    status = 'emptyString';
  }
  // console.log('status After:',status);
  const queryParams = new URLSearchParams({
    search,
    categories,
    sortBy,
    status,
    page: pageInfo.page.toString(),
    size: pageInfo.size.toString(),
  }).toString();

  const res = await client.get(`article?${queryParams}`);
  // 응답전체 데이터
  // console.log(res);
  console.log(res.data);
  return res.data;
}

// Filters -> RequestFilters 변환 함수
const transformFilters = (filters: Filters): RequestFilters => {
  return {
    ...filters,
    status: filters.status.join(','), // 배열을 문자열로 변환
  };
};

// Search 데이터를 활용한 Question Post List 데이터 호출
export const PostsQuery = (filters: Filters) => {
  const requestFilters = transformFilters(filters);

  return useQuery<Question, Error>({
    queryKey: ['posts', filters],
    queryFn: () => fetchPosts(requestFilters),
    // 사용자가 다른 창이나 탭으로 이동했다가 다시 돌아왔을 때 데이터를 자동으로 새로고침하지 않습니다
    refetchOnWindowFocus:true,
    // 인터넷 연결이 끊어졌다가 다시 연결되었을 때 데이터를 자동으로 새로고침하지 않습니다
    refetchOnMount:false
  });
};
```

## 💬 Review Requirements
> 해당 방법이 괜찮은지 궁금하고 혹시 다른 방법이 있으시다면 코멘트 부탁드립니다