### PR TITLE
Feature/#21 qna post write and edit and delete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,10 @@ const router = createBrowserRouter([
     element: <PostWritePage />,
   },
   {
+    path: '/edit/:postId',
+    element: <PostWritePage />
+  },
+  {
     path: '/posts/:postId',
     element: <PostDetailPage />,
   },

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import { postFile } from '../services/http';
+import { useMutation } from '@tanstack/react-query';
 
 const modules = {
   toolbar: [
@@ -47,6 +48,16 @@ interface Props {
 function Editor({ content, setContent, width = 'auto', height = 600 }: Props) {
   const quillRef = useRef<ReactQuill | null>(null);
 
+  const {
+    mutate, error: mutationError,
+  } = useMutation({
+    mutationFn: postFile,
+    onSuccess: (data, variables, context) => {
+      const { imageUrl } = data;
+      insertImageToEditor(imageUrl);
+    },
+  });
+
   const handleImage = async () => {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
@@ -58,14 +69,27 @@ function Editor({ content, setContent, width = 'auto', height = 600 }: Props) {
         try {
           const base64String = await readFileAsBase64(input.files[0]);
           const base64File = `data:${input.files[0].type};base64,${base64String}`;
-          await postFile({ base64File, targetId: 1 });
+          mutate({ base64File, targetId: 1 });
         } catch (error) {
           console.error(error);
+        } finally {
+          // 임시
         }
       } else {
         alert('Please select a file.');
       }
     });
+  };
+
+  const insertImageToEditor = (imageUrl: string) => {
+    const editor = quillRef.current?.getEditor();
+    const range = editor?.getSelection(true);
+
+    if (range) {
+      editor?.insertEmbed(range.index, 'image', imageUrl);
+      range.index += 1; // Move the cursor to the next position
+      editor?.setSelection(range.index);
+    }
   };
 
   useEffect(() => {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -72,8 +72,6 @@ function Editor({ content, setContent, width = 'auto', height = 600 }: Props) {
           mutate({ base64File, targetId: 1 });
         } catch (error) {
           console.error(error);
-        } finally {
-          // 임시
         }
       } else {
         alert('Please select a file.');

--- a/src/components/detail/Post/index.tsx
+++ b/src/components/detail/Post/index.tsx
@@ -4,12 +4,16 @@ import { Container } from './styles';
 import { useQuery } from '@tanstack/react-query';
 import { getPost } from '../../../services/post.ts';
 import { getAvatar } from '../../../services/avatar.ts';
+import { useEffect, useRef } from 'react';
 
 interface Props {
   postId : number;
 }
 
 function Post({postId} : Props) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+
   // 게시글 데이터 호출
   const { data : postData, isLoading: isLoadingPost, isError: isErrorPost} = useQuery({
     queryKey : ["postData", postId],
@@ -24,6 +28,16 @@ function Post({postId} : Props) {
 
   const isLoading = isLoadingPost || isLoadingAvatar;
   const isError = isErrorPost || isErrorAvatar;
+
+  useEffect(() => {
+    if (contentRef.current && postData) {
+      contentRef.current.innerHTML = postData.data.content;
+      const images = contentRef.current.getElementsByTagName('img');
+      for (let img of images) {
+        img.src = img.src; // force reload the image
+      }
+    }
+  }, [postData]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -45,11 +59,12 @@ function Post({postId} : Props) {
           <li key={tag}>#{tag}</li>
         ))}
       </div>
-      <div
-        dangerouslySetInnerHTML={{
-          __html: content,
-        }}
-      />
+      <div ref={contentRef} />
+      {/*<div*/}
+      {/*  dangerouslySetInnerHTML={{*/}
+      {/*    __html: content,*/}
+      {/*  }}*/}
+      {/*/>*/}
       <WriterProfile userId={userId} userName={userName} avatar={avatar} avatarTags={avatarTags} comment={comment} />
     </Container>
   );

--- a/src/components/write/ActionButtons/index.tsx
+++ b/src/components/write/ActionButtons/index.tsx
@@ -1,16 +1,43 @@
 import { BiRightArrowAlt } from 'react-icons/bi';
 import { Container } from './styles';
 
-function ActionButtons() {
+function ActionButtons({ onCancel, onSave, onSubmit, onUpdate, editVisible }) {
   return (
     <Container>
-      <button className="btn-save" type="button">
-        Save
+      <button
+        className="btn-save"
+        type="button"
+        onClick={onCancel}
+      >
+        취소
       </button>
-      <button className="btn-post">
-        Post
-        <BiRightArrowAlt />
+      <button
+        className="btn-save"
+        type="button"
+        onClick={onSave}
+      >
+        임시저장
       </button>
+      {!editVisible && (
+        <button
+          className="btn-post"
+          type="button"
+          onClick={onSubmit}
+        >
+          저장
+          <BiRightArrowAlt />
+        </button>
+      )}
+      {editVisible && (
+        <button
+          className="btn-post"
+          type="button"
+          onClick={onUpdate}
+        >
+          수정
+          <BiRightArrowAlt />
+        </button>
+      )}
     </Container>
   );
 }

--- a/src/components/write/ActionButtons/index.tsx
+++ b/src/components/write/ActionButtons/index.tsx
@@ -1,7 +1,25 @@
 import { BiRightArrowAlt } from 'react-icons/bi';
 import { Container } from './styles';
+import { useEffect, useState } from 'react';
 
-function ActionButtons({ onCancel, onSave, onSubmit, onUpdate, editVisible }) {
+function ActionButtons({ onCancel, onSave, onSubmit, onUpdate, onDelete, editVisible }) {
+
+  // 수정 페이지 진입시 저장 버튼이 나왔다가 사라짐
+  // 원인은 랜더링이 너무 빨라서 딜레이가 필요해보임
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(true);
+    }, 100); // 딜레이 조정 (단위 : milliseconds)
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!isVisible) {
+    return null;
+  }
+
   return (
     <Container>
       <button
@@ -18,6 +36,15 @@ function ActionButtons({ onCancel, onSave, onSubmit, onUpdate, editVisible }) {
       >
         임시저장
       </button>
+      {editVisible && (
+        <button
+          className="btn-delete"
+          type="button"
+          onClick={onDelete}
+        >
+          삭제
+        </button>
+      )}
       {!editVisible && (
         <button
           className="btn-post"

--- a/src/components/write/ActionButtons/styles.tsx
+++ b/src/components/write/ActionButtons/styles.tsx
@@ -1,33 +1,39 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 70px;
-
-  button {
-    font-size: 16px;
-    outline: none;
-    border-radius: 8px;
-    padding: 10px 15px;
     display: flex;
-    justify-content: center;
-    align-items: center;
-  }
+    justify-content: flex-end;
+    margin-top: 70px;
 
-  button + button {
-    margin-left: 10px;
-  }
+    button {
+        font-size: 16px;
+        outline: none;
+        border-radius: 8px;
+        padding: 10px 15px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
 
-  .btn-save {
-    background-color: #f8faff;
-    color: #6d758f;
-    border: 1px solid #e1e4ed;
-  }
+    button + button {
+        margin-left: 10px;
+    }
 
-  .btn-post {
-    background-color: #6d758f;
-    border: none;
-    color: #fff;
-  }
+    .btn-delete {
+        background-color: #da5747;
+        border: none;
+        color: #fff;
+    }
+
+    .btn-save {
+        background-color: #f8faff;
+        color: #6d758f;
+        border: 1px solid #e1e4ed;
+    }
+
+    .btn-post {
+        background-color: #6d758f;
+        border: none;
+        color: #fff;
+    }
 `;

--- a/src/components/write/CategorySelect/index.tsx
+++ b/src/components/write/CategorySelect/index.tsx
@@ -5,7 +5,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { Wrapper } from './styles';
 
 interface Props {
-  category: 'question' | 'free' | undefined;
+  category: 'question' | 'free';
   onCategoryChange: (category: 'question' | 'free') => void;
 }
 

--- a/src/components/write/TagAutocomplete/index.tsx
+++ b/src/components/write/TagAutocomplete/index.tsx
@@ -3,18 +3,13 @@ import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Wrapper } from './styles';
+import { useQuery } from '@tanstack/react-query';
+import { getPost } from '../../../services/post.ts';
+import { getCategories } from '../../../services/category.ts';
 
 interface Props {
   tagList: string[];
   onTagListChange: (tagList: string[]) => void;
-}
-
-function sleep(duration: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, duration);
-  });
 }
 
 function TagAutocomplete({ tagList, onTagListChange }: Props) {
@@ -22,25 +17,19 @@ function TagAutocomplete({ tagList, onTagListChange }: Props) {
   const [options, setOptions] = useState<string[]>([]);
   const loading = open && options.length === 0;
 
+  // 게시글 데이터 호출
+  const { data : tagListData, isLoading: isLoadingTagListData, isError: isErrorTagListData} = useQuery({
+    queryKey : ["tagListData"],
+    queryFn: () => getCategories(),
+  });
+
   useEffect(() => {
-    let active = true;
-
-    if (!loading) {
-      return undefined;
+    console.log(tagListData);
+    if (tagListData) {
+      const names = tagListData.data.map(item => item.name);
+      setOptions(names);
     }
-
-    (async () => {
-      await sleep(1e3);
-
-      if (active) {
-        setOptions(['javascript', 'react', 'python', 'Node.js']);
-      }
-    })();
-
-    return () => {
-      active = false;
-    };
-  }, [loading]);
+  }, [tagListData]);
 
   const handleChange = (_: React.SyntheticEvent, value: string[]) => {
     onTagListChange(value);

--- a/src/pages/PostWritePage.tsx
+++ b/src/pages/PostWritePage.tsx
@@ -6,19 +6,32 @@ import Editor from '../components/Editor';
 import CategorySelect from '../components/write/CategorySelect';
 import TagAutocomplete from '../components/write/TagAutocomplete';
 import ActionButtons from '../components/write/ActionButtons';
-import { createNewArticle } from '../services/http';
+import { createNewArticle } from '../services/post';
+import Navbar from '../components/NavBar.tsx';
+import { useNavigate } from 'react-router-dom';
+import { NotificationModal } from '../components/modal/NotificationModal.tsx';
 
 function PostWritePage() {
-  const [category, setCategory] = useState<'question' | 'free' | undefined>();
+  const [category, setCategory] = useState<'question' | 'free'>('question');
   const [title, setTitle] = useState('');
   const [tagList, setTagList] = useState<string[]>([]);
   const [content, setContent] = useState('');
+
+  const [isModalVisible, setModalVisible] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+
+  const navigate = useNavigate();
 
   const { mutate, isPending, isError, error } = useMutation({
     mutationFn: createNewArticle,
     onSuccess: () => {
       console.log('성공!');
+      navigate("/board/question");
     },
+    onError: () => {
+      setModalMessage('서버 통신 실패');
+      setModalVisible(true);
+    }
   });
 
   const handleCategoryChange = (category: 'question' | 'free') => {
@@ -33,21 +46,30 @@ function PostWritePage() {
     setTagList(tagList);
   };
 
+  // 취소
+  const handelCancel = () => {
+    navigate("/board/question");
+  }
+
+  // 임시저장
+  const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
+  // 저장
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    mutate({ category: category, title: title, tagList:tagList, contentText: JSON.stringify(content)});
+  };
 
-    mutate({ title, contentText: JSON.stringify(content)});
-
-    console.log({
-      category,
-      title,
-      tagList,
-      content,
-    });
+  // 모달창 Close 버튼 클릭시 동작 함수
+  const handleCloseModal = () => {
+    setModalVisible(false);
   };
 
   return (
     <Container>
+      <Navbar/>
       <Form onSubmit={handleSubmit}>
         <Header>
           <CategorySelect category={category} onCategoryChange={handleCategoryChange} />
@@ -55,8 +77,13 @@ function PostWritePage() {
           <TagAutocomplete tagList={tagList} onTagListChange={handleTagListChange} />
         </Header>
         <Editor content={content} setContent={setContent} />
-        <ActionButtons />
+        <ActionButtons onCancel={handelCancel} onSave={handleSave} onSubmit={handleSubmit} />
       </Form>
+      <NotificationModal
+        message={modalMessage}
+        isVisible={isModalVisible}
+        onClose={handleCloseModal}
+      />
     </Container>
   );
 }

--- a/src/pages/PostWritePage.tsx
+++ b/src/pages/PostWritePage.tsx
@@ -6,7 +6,7 @@ import Editor from '../components/Editor';
 import CategorySelect from '../components/write/CategorySelect';
 import TagAutocomplete from '../components/write/TagAutocomplete';
 import ActionButtons from '../components/write/ActionButtons';
-import { createNewArticle, getPost, updateArticle } from '../services/post';
+import { createNewArticle, deleteArticle, getPost, updateArticle } from '../services/post';
 import Navbar from '../components/NavBar.tsx';
 import { useNavigate, useParams } from 'react-router-dom';
 import { NotificationModal } from '../components/modal/NotificationModal.tsx';
@@ -93,6 +93,20 @@ function PostWritePage() {
     }
   });
 
+  // 게시글 삭제
+  const { mutate : deleteMutate } = useMutation({
+    mutationFn: deleteArticle,
+    onSuccess: () => {
+      console.log('성공!');
+      navigate("/board/question");
+    },
+    onError: () => {
+      setModalMessage('서버 통신 실패');
+      setModalVisible(true);
+    }
+  });
+
+
   const handleCategoryChange = (category: 'question' | 'free') => {
     setCategory(category);
   };
@@ -133,6 +147,12 @@ function PostWritePage() {
     updateMutate({ postId: Number(postId), updateArticle: updateData });
   };
 
+  // 삭제
+  const handleDelete = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    deleteMutate(Number(postId))
+  }
+
   // 모달창 Close 버튼 클릭시 동작 함수
   const handleCloseModal = () => {
     setModalVisible(false);
@@ -148,7 +168,7 @@ function PostWritePage() {
           <TagAutocomplete tagList={tagList} onTagListChange={handleTagListChange} />
         </Header>
         <Editor content={content} setContent={setContent} />
-        <ActionButtons onCancel={handelCancel} onSave={handleSave} onSubmit={handleSubmit} onUpdate={handleUpdate} editVisible={editVisible} />
+        <ActionButtons onCancel={handelCancel} onSave={handleSave} onSubmit={handleSubmit} onUpdate={handleUpdate} onDelete={handleDelete} editVisible={editVisible} />
       </Form>
       <NotificationModal
         message={modalMessage}

--- a/src/pages/PostWritePage.tsx
+++ b/src/pages/PostWritePage.tsx
@@ -1,15 +1,21 @@
-import React, { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import TextField from '@mui/material/TextField';
 import Editor from '../components/Editor';
 import CategorySelect from '../components/write/CategorySelect';
 import TagAutocomplete from '../components/write/TagAutocomplete';
 import ActionButtons from '../components/write/ActionButtons';
-import { createNewArticle } from '../services/post';
+import { createNewArticle, getPost, updateArticle } from '../services/post';
 import Navbar from '../components/NavBar.tsx';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { NotificationModal } from '../components/modal/NotificationModal.tsx';
+
+interface PostData {
+  title: string;
+  tags: string[];
+  content: string;
+}
 
 function PostWritePage() {
   const [category, setCategory] = useState<'question' | 'free'>('question');
@@ -22,8 +28,61 @@ function PostWritePage() {
 
   const navigate = useNavigate();
 
-  const { mutate, isPending, isError, error } = useMutation({
+  const { postId } = useParams();
+  const [editData, setEditData ] = useState<PostData>();
+  const [editVisible, setEditVisible] = useState(false);
+
+  // postId 데이터 있으면 한 번 실행
+  // edit 로 들어오는 경우
+  useEffect(() => {
+    if (postId) {
+      // 게시글 데이터 호출
+      (async () => {
+        const response = await getPost(Number(postId));
+        console.log(response);
+        if (response && response.data) {
+          setEditData(response.data);
+        }
+      })();
+    }
+  }, [postId]);
+
+  // 글 수정 데이터 있으면 수정 에디터 폼으로 변경
+  useEffect(() => {
+    if (editData) {
+      setCategory('question');
+      setTitle(editData.title);
+      setTagList(editData.tags);
+      setContent(editData.content);
+      setEditVisible(true);
+    }
+  }, [editData]);
+
+  // 게시글 생성
+  const { mutate: createMutate } = useMutation({
     mutationFn: createNewArticle,
+    onSuccess: () => {
+      console.log('성공!');
+      navigate("/board/question");
+    },
+    onError: () => {
+      setModalMessage('서버 통신 실패');
+      setModalVisible(true);
+    }
+  });
+
+  // 게시글 수정
+  const { mutate : updateMutate } = useMutation({
+    mutationFn: (
+      data: {
+        postId: number,
+        updateArticle: {
+          category: string | undefined;
+          title: string;
+          tagList: string[];
+          contentText: string;
+        }
+      }) => updateArticle(data.postId, data.updateArticle),
     onSuccess: () => {
       console.log('성공!');
       navigate("/board/question");
@@ -59,7 +118,19 @@ function PostWritePage() {
   // 저장
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    mutate({ category: category, title: title, tagList:tagList, contentText: JSON.stringify(content)});
+    createMutate({ category: category, title: title, tagList:tagList, contentText: JSON.stringify(content)});
+  };
+  
+  // 수정
+  const handleUpdate = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const updateData = {
+      category: category,
+      title: title,
+      tagList:tagList,
+      contentText: JSON.stringify(content)
+    }
+    updateMutate({ postId: Number(postId), updateArticle: updateData });
   };
 
   // 모달창 Close 버튼 클릭시 동작 함수
@@ -77,7 +148,7 @@ function PostWritePage() {
           <TagAutocomplete tagList={tagList} onTagListChange={handleTagListChange} />
         </Header>
         <Editor content={content} setContent={setContent} />
-        <ActionButtons onCancel={handelCancel} onSave={handleSave} onSubmit={handleSubmit} />
+        <ActionButtons onCancel={handelCancel} onSave={handleSave} onSubmit={handleSubmit} onUpdate={handleUpdate} editVisible={editVisible} />
       </Form>
       <NotificationModal
         message={modalMessage}

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -1,0 +1,8 @@
+import client from './client.ts';
+
+// 카테고리 목록 호출
+export const getCategories = async () => {
+  const response = await client.get(`categories`);
+  console.log(response.data);
+  return response.data;
+}

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,24 +1,12 @@
 import client from './client';
 
-export const createNewArticle = async (newArticle: { title: string; contentText: string }) => {
-  try {
-    const response = await client.post('articles', newArticle);
 
-    console.log(response.data);
-
-    return response.data;
-  } catch (error) {
-    console.error(error);
-
-    throw error;
-  }
-};
 
 export const postFile = async (file: { base64File: string; targetId: number }) => {
   try {
     const response = await client.post('files', file);
-
     console.log(response.data);
+    return response.data;
   } catch (error) {
     console.error(error);
 

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -22,6 +22,23 @@ export const createNewArticle = async (newArticle: {
     }
 };
 
+// 게시글 수정
+export const updateArticle = async (postId: number, updateArticle: {
+      category: string | undefined;
+      title: string;
+      tagList: string[];
+      contentText: string;
+    }) => {
+    try {
+      const response = await client.put(`articles/${postId}`, updateArticle);
+      console.log(response.data);
+      return response.data;
+    } catch (error) {
+      console.log(error);
+      throw error;
+    }
+};
+
 // 게시글 리스트 불러오기
 const fetchPosts = async (filters: RequestFilters): Promise<Question> => {
   const { search, categories, sortBy, pageInfo } = filters;

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -39,6 +39,17 @@ export const updateArticle = async (postId: number, updateArticle: {
     }
 };
 
+export const deleteArticle = async (postId: number) => {
+  try {
+    const response = await client.delete(`articles/${postId}`);
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+}
+
 // 게시글 리스트 불러오기
 const fetchPosts = async (filters: RequestFilters): Promise<Question> => {
   const { search, categories, sortBy, pageInfo } = filters;

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -3,6 +3,26 @@ import { Question } from '../responseType/postType.ts';
 import { useQuery } from '@tanstack/react-query';
 import { Filters, RequestFilters } from '../requestType/postType.ts';
 
+// 게시글 생성
+export const createNewArticle = async (newArticle: {
+      category: string | undefined;
+      title: string;
+      tagList: string[];
+      contentText: string;
+    }) => {
+    try {
+      // console.log(`Request : newArticle => ${newArticle.category} \n ${newArticle.title} \n ${newArticle.tagList} \n ${newArticle.contentText} `)
+      const response = await client.post('articles', newArticle);
+      // console.log(response.data);
+      return response.data;
+    } catch (error) {
+      console.error(error);
+
+      throw error;
+    }
+};
+
+// 게시글 리스트 불러오기
 const fetchPosts = async (filters: RequestFilters): Promise<Question> => {
   const { search, categories, sortBy, pageInfo } = filters;
   let { status } = filters;
@@ -100,6 +120,7 @@ export const updateStatusWrapper = ({ postId, data }: { postId: number, data: Up
   return updateStatus(postId, data);
 }
 
+// 좋아요 갯수 불러오기
 export const getLikesCount = async (postId: number) => {
   const response = await client.get(`articles/${postId}/likesCount`);
   console.log(response.data);
@@ -115,6 +136,7 @@ interface UpdateLikeProps {
   postId: number;
 }
 
+// 게시글 좋아요 업데이트
 export const updateLike = async ({ data, postId }: UpdateLikeProps) => {
   try {
     const response = await client.post(`articles/${postId}/like`, data);

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -39,6 +39,7 @@ export const updateArticle = async (postId: number, updateArticle: {
     }
 };
 
+// 게시글 삭제
 export const deleteArticle = async (postId: number) => {
   try {
     const response = await client.delete(`articles/${postId}`);


### PR DESCRIPTION
## 🚀 Related Issues
> https://github.com/ChatCode9/ChatCode-frontend/issues/21
## 🛠️ Summary
> 1) 게시글 작성/수정 페이지에서 사용되는 태그 카테고리 호출 API 생성 - src/services/category.ts
https://github.com/ChatCode9/ChatCode-frontend/commit/f25a5903292bce57aa9617945a5a701b9be62219

2) 게시글 수정 페이지 진입시 아래 버튼 "취소", "임시저장", "삭제", "저장" 으로 구분

3) PostWritePage.tsx 컴포넌트는 기존에는 게시글 작성에만 사용했지만
기존 데이터가 존재하면 수정 컴포넌트로 동작되도록 조치
대신 App.tsx 에서 Router 에서 분기처리함
https://github.com/ChatCode9/ChatCode-frontend/commit/a3ef16ea6e0c7d9212772bcea8020ed20ae59b98

3) 에디터 이미지 추가시 에디터내 이미지 랜더링 되도록 기능 구현 - src/components/Editor.tsx > insertImageToEditor 함수
https://github.com/ChatCode9/ChatCode-frontend/commit/4a2594a4348b6431c4cdf5304c0e444aebe533fe

## 💬 Review Requirements
> 코드 리뷰 바랍니다. 별 이상 없으면 Merge 진행하도록 하겠습니다.
